### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ var config = {
 ## Configuration options
 | Option           | Type       | Default 		| Description
 |----------------- |----------- |-------------- | ---------------
-| `updateInterval` | `number`	| `600`			| Update interval in seconds. Not less then 300 (5min) according to Terms
+| `updateInterval` | `number`	| `600000`		| Update interval in seconds. Not less then 300 (5min) according to Terms
 | `maxWidth`       | `string`   | `200px`       | Max width of the module
 | `url`        	   | `string`	| `https://creativecommons.tankerkoenig.de/json/list.php` | Address to fetch prices from.
 | `api_key`		   | `string`	| `null`		| API Key from https://creativecommons.tankerkoenig.de/


### PR DESCRIPTION
@terenc3:
Please re-consider your decision of my previous pull-request (Update README.md)
According to the service provider "Tankerkoenig" a value of 600 will block the API-key.

This is what the service provider Tankerkoening is saying:

Im Original MMM-Modul wird das Intervall in Millisekunden angegeben. Meine Vermutung: der Autor hat zwar die Interpretation des Timing-Wertes als Millisekunden übernommen, aber das falsch dokumentiert und den falschen Wert von 600 angegeben. Entsprechend wird alle 600 ms ein Request abgesetzt, der ziemlich zügig zur Sperrung führt.
Du solltest die Einstellung auf 600000 (sechshunderttausend) ändern und - nach erfolgreichem Test - dem Autor des Moduls über seinen Fehler Bescheid geben, damit er das korrigieren kann.

ein Blick in das Log unseres Servers:
> 12.345.67.890 - - [22/Apr/2019:10:13:05 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 200 4265
> 12.345.67.890 - - [22/Apr/2019:10:13:05 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 200 4265
> 12.345.67.890 - - [22/Apr/2019:10:13:06 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 200 4265
> 12.345.67.890 - - [22/Apr/2019:10:13:07 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 200 4265
> 12.345.67.890 - - [22/Apr/2019:10:13:08 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:08 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:09 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:09 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:10 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:10 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:11 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:11 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:12 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 
> 12.345.67.890 - - [22/Apr/2019:10:13:13 +0200] "GET /json/list.php?lat=43.<***value***>&lng=9.<***value***>&rad=5&type=all&apikey=<***value***>&sort=dist HTTP/1.1" 503 643 

zeigt, dass die Request ein bis zweimal pro Sekunde kommen - also *nicht* alle 600 Sekunden, wie die Anleitung vermuten läßt.
Im Original MMM-Modul wird das Intervall in Millisekunden angegeben. Meine Vermutung: der Autor hat zwar die Interpretation des Timing-Wertes als Millisekunden übernommen, aber das falsch dokumentiert und den falschen Wert von 600 angegeben. Entsprechend wird alle 600 ms ein Request abgesetzt, der ziemlich zügig zur Sperrung führt.
Du solltest die Einstellung auf 600000 (sechshunderttausend) ändern und - nach erfolgreichem Test - dem Autor des Moduls über seinen Fehler Bescheid geben, damit er das korrigieren kann.

Best regards